### PR TITLE
fix: SetLineStr関数が存在しない問題を修正

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -37,13 +37,15 @@ if (text.indexOf("□") !== -1) {
 
 ### 2. サクラエディタAPI問題
 
-#### `Editor.SetLineStr()` 引数順序
+#### `Editor.SetLineStr()` 関数問題
 ```javascript
-// ❌ 間違った引数順序
-Editor.SetLineStr(newLineText, 0);
-
-// ✅ 正しい引数順序
+// ❌ 存在しない関数
 Editor.SetLineStr(0, newLineText);
+
+// ✅ 正しい実装方法
+Editor.GoLineTop(0);          // 行頭に移動
+Editor.SelectLine();          // 行全体を選択
+Editor.InsText(newLineText);  // 選択範囲を置換
 ```
 
 #### `Editor.GetLineStr()` 使用方法
@@ -64,7 +66,8 @@ var currentLineText = Editor.GetLineStr(0);
 
 ### サクラエディタAPI
 - [x] `Editor.GetLineStr(行番号)` - 正しく使用
-- [x] `Editor.SetLineStr(行番号, テキスト)` - 引数順序修正
+- [x] `Editor.SetLineStr()` - 存在しない関数を正しいAPI呼び出しに修正
+- [x] `Editor.GoLineTop()`, `Editor.SelectLine()`, `Editor.InsText()` - 組み合わせで行置換
 
 ### ES5準拠の書き方
 
@@ -132,5 +135,6 @@ return {
 
 - 2025-06-20: 初版作成
   - `startsWith()` → `indexOf()` 修正
-  - `Editor.SetLineStr()` 引数順序修正
+  - `Editor.SetLineStr()` 存在しない関数問題を修正
+  - 正しいサクラエディタAPI使用方法に変更
   - 互換性ガイドライン策定

--- a/todo.md
+++ b/todo.md
@@ -65,5 +65,16 @@
 ## 修正履歴
 ### 2025-06-20 互換性問題修正
 - ❌ `startsWith()` → ✅ `indexOf() === 0`
-- ❌ `Editor.SetLineStr(text, line)` → ✅ `Editor.SetLineStr(line, text)`
+- ❌ `Editor.SetLineStr()` (存在しない関数) → ✅ 正しいAPI組み合わせに修正
 - ES5準拠コードに統一
+
+### API修正詳細
+```javascript
+// 修正前（存在しない関数）
+Editor.SetLineStr(0, newLineText);
+
+// 修正後（正しいAPI）
+Editor.GoLineTop(0);          // 行頭に移動
+Editor.SelectLine();          // 行全体を選択  
+Editor.InsText(newLineText);  // 選択範囲を置換
+```

--- a/todo_toggle_integrated.js
+++ b/todo_toggle_integrated.js
@@ -116,7 +116,9 @@ function main() {
     var newLineText = indentProcessor.replaceText(currentLineText, newText);
     
     // 現在の行を新しい内容で置換
-    Editor.SetLineStr(0, newLineText);
+    Editor.GoLineTop(0);          // 行頭に移動
+    Editor.SelectLine();          // 行全体を選択
+    Editor.InsText(newLineText);  // 選択範囲を置換
 }
 
 // マクロのエントリーポイント

--- a/toggle_todo_symbols.js
+++ b/toggle_todo_symbols.js
@@ -34,7 +34,9 @@ function main() {
     var newLineText = indentPart + nextSymbol + remainingText;
     
     // 現在の行を新しい内容で置換
-    Editor.SetLineStr(0, newLineText);
+    Editor.GoLineTop(0);          // 行頭に移動
+    Editor.SelectLine();          // 行全体を選択
+    Editor.InsText(newLineText);  // 選択範囲を置換
 }
 
 // 記号状態判定ロジック：次の記号を決定する


### PR DESCRIPTION
## 問題概要
`Editor.SetLineStr()` 関数がサクラエディタのJavaScriptマクロAPIに存在せず、Line 37で「オブジェクトでサポートされていないプロパティまたはメソッドです」エラーが発生していた。

## 調査結果
サクラエディタ公式ドキュメント調査により、`SetLineStr` 関数は存在しないことが判明。行の置換には別のAPI組み合わせが必要。

## 修正内容

### API修正
```javascript
// ❌ 修正前（存在しない関数）
Editor.SetLineStr(0, newLineText);

// ✅ 修正後（正しいAPI組み合わせ）
Editor.GoLineTop(0);          // 行頭に移動
Editor.SelectLine();          // 行全体を選択
Editor.InsText(newLineText);  // 選択範囲を置換
```

### 修正ファイル
- **toggle_todo_symbols.js**: メインマクロの修正
- **todo_toggle_integrated.js**: 統合版マクロの修正
- **COMPATIBILITY.md**: API仕様ドキュメント更新
- **todo.md**: 修正履歴の追加

## 技術詳細

### サクラエディタAPI仕様
- ✅ `Editor.GetLineStr(行番号)` - 行取得（存在）
- ❌ `Editor.SetLineStr()` - 行設定（存在しない）
- ✅ `Editor.GoLineTop()` - 行移動（存在）
- ✅ `Editor.SelectLine()` - 行選択（存在）
- ✅ `Editor.InsText()` - テキスト挿入（存在）

### 動作フロー
1. `GoLineTop(0)`: 現在行の行頭に移動
2. `SelectLine()`: 行全体を選択状態にする
3. `InsText(newText)`: 選択範囲を新しいテキストで置換

## テスト計画
- [x] 存在しない関数の特定と修正
- [x] 正しいAPI組み合わせの実装
- [x] 全対象ファイルの修正完了
- [x] ドキュメントの更新
- [ ] 実際のサクラエディタでの動作確認（ユーザー側）

## 期待される結果
この修正により、Line 37エラーが解消され、サクラエディタでマクロが正常に動作するようになります。

Closes #11

🤖 Generated with [Claude Code](https://claude.ai/code)