### PR TITLE
fix: 文字化け問題を修正（Unicode Escape Sequence使用）

### DIFF
--- a/CHARACTER_ENCODING_GUIDE.md
+++ b/CHARACTER_ENCODING_GUIDE.md
@@ -1,0 +1,154 @@
+# 文字エンコーディング対策ガイド
+
+## 問題の概要
+
+サクラエディタでTODO記号 □◆■ が文字化けして表示される問題の対策ガイドです。
+
+## 文字化け例
+
+### 発生する文字化け
+```
+期待: □◆■
+実際: 笹。箇・。笹・・。
+```
+
+### 文字化けパターン
+- `□` → `笹。`
+- `◆` → `箇・`  
+- `■` → `笹・・`
+
+## 原因
+
+### エンコーディング不一致
+- **JavaScriptファイル**: UTF-8で保存
+- **サクラエディタ**: Shift_JISで動作
+- **結果**: Unicode文字の解釈が異なり文字化け
+
+## 解決方法
+
+### Unicode Escape Sequenceの使用
+
+#### 修正前（文字化けする）
+```javascript
+var symbols = ["□", "◆", "■"];
+if (text.indexOf("□") === 0) {
+    // 文字化けが発生
+}
+```
+
+#### 修正後（文字化けしない）
+```javascript
+var symbols = ["\u25A1", "\u25C6", "\u25A0"];  // □ ◆ ■
+if (text.indexOf("\u25A1") === 0) {
+    // Unicode Escape Sequenceで確実に動作
+}
+```
+
+## Unicode文字コード表
+
+### TODO記号のUnicodeコード
+| 記号 | 名前 | Unicodeコード | Escape Sequence |
+|------|------|---------------|-----------------|
+| □ | 白四角 | U+25A1 | `\u25A1` |
+| ◆ | 黒ダイヤ | U+25C6 | `\u25C6` |
+| ■ | 黒四角 | U+25A0 | `\u25A0` |
+
+### その他のよく使用される記号
+| 記号 | 名前 | Unicodeコード | Escape Sequence |
+|------|------|---------------|-----------------|
+| ○ | 白丸 | U+25CB | `\u25CB` |
+| ● | 黒丸 | U+25CF | `\u25CF` |
+| △ | 白三角 | U+25B3 | `\u25B3` |
+| ▲ | 黒三角 | U+25B2 | `\u25B2` |
+| ☆ | 白星 | U+2606 | `\u2606` |
+| ★ | 黒星 | U+2605 | `\u2605` |
+
+## 実装例
+
+### 基本的な使用方法
+```javascript
+// Unicode Escape Sequenceを使用した安全な実装
+function getSymbolName(symbol) {
+    switch (symbol) {
+        case "\u25A1":  // □
+            return "未完了";
+        case "\u25C6":  // ◆
+            return "進行中";
+        case "\u25A0":  // ■
+            return "完了";
+        default:
+            return "不明";
+    }
+}
+```
+
+### 動的な記号生成
+```javascript
+// 記号配列の定義
+var TODO_SYMBOLS = {
+    PENDING: "\u25A1",    // □ 未完了
+    PROGRESS: "\u25C6",   // ◆ 進行中
+    COMPLETED: "\u25A0"   // ■ 完了
+};
+
+// 使用例
+var currentSymbol = TODO_SYMBOLS.PENDING;  // □
+```
+
+## 検証方法
+
+### 1. ファイル保存時の確認
+```javascript
+// テスト用コード（マクロ内に一時的に追加）
+Editor.InsText("Test: " + "\u25A1" + "\u25C6" + "\u25A0");
+// 実行結果が「Test: □◆■」になることを確認
+```
+
+### 2. 文字化けチェック
+```javascript
+// 各記号の正常表示確認
+var symbols = ["\u25A1", "\u25C6", "\u25A0"];
+for (var i = 0; i < symbols.length; i++) {
+    Editor.InsText("Symbol " + i + ": " + symbols[i] + "\n");
+}
+```
+
+## 注意事項
+
+### やってはいけないこと
+- ❌ 直接文字をコードに記述
+- ❌ コピー&ペーストでの文字入力
+- ❌ 文字コード混在
+
+### 推奨する方法
+- ✅ Unicode Escape Sequenceを使用
+- ✅ 定数として文字を定義
+- ✅ コメントで文字の意味を明記
+
+## トラブルシューティング
+
+### Q1: 修正後も文字化けする
+**A1:** 以下を確認
+- Escape Sequenceの記述が正しいか
+- ファイルがUTF-8で保存されているか
+- サクラエディタの文字コード設定
+
+### Q2: 他の記号も文字化けする
+**A2:** 同様にUnicode Escape Sequenceに変更
+- Unicode表でコードを確認
+- `\uXXXX` 形式で記述
+
+### Q3: 日本語コメントが文字化けする
+**A3:** ファイルエンコーディングを確認
+- JavaScriptファイルをShift_JISで保存
+- または英語コメントのみ使用
+
+## まとめ
+
+Unicode Escape Sequenceを使用することで：
+- ✅ 環境に依存しない文字表示
+- ✅ 文字化けの完全防止
+- ✅ 保守性の向上
+- ✅ 安定した動作
+
+この方法により、どのような環境でもTODO記号が正しく表示されます。

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -6,7 +6,25 @@
 
 ## 修正済み問題
 
-### 1. ES6メソッドの互換性問題
+### 1. 文字エンコーディング問題
+
+#### Unicode Escape Sequence使用
+```javascript
+// ❌ 文字化けする（直接文字指定）
+var symbols = ["□", "◆", "■"];
+if (text.indexOf("□") === 0) {
+
+// ✅ 文字化けしない（Unicode Escape）
+var symbols = ["\u25A1", "\u25C6", "\u25A0"];  // □ ◆ ■
+if (text.indexOf("\u25A1") === 0) {
+```
+
+#### Unicode文字コード一覧
+- □ (白四角): `\u25A1`
+- ◆ (黒ダイヤ): `\u25C6`
+- ■ (黒四角): `\u25A0`
+
+### 2. ES6メソッドの互換性問題
 
 #### `startsWith()` メソッド
 ```javascript
@@ -35,7 +53,7 @@ if (text.includes("□")) {
 if (text.indexOf("□") !== -1) {
 ```
 
-### 2. サクラエディタAPI問題
+### 3. サクラエディタAPI問題
 
 #### `Editor.SetLineStr()` 関数問題
 ```javascript
@@ -55,6 +73,11 @@ var currentLineText = Editor.GetLineStr(0);
 ```
 
 ## 互換性チェックリスト
+
+### 文字エンコーディング
+- [x] 直接文字指定 → Unicode Escape Sequence
+- [x] □◆■ → `\u25A1` `\u25C6` `\u25A0`
+- [x] 環境に依存しない文字表示
 
 ### JavaScriptメソッド
 - [x] `startsWith()` → `indexOf() === 0`
@@ -134,6 +157,7 @@ return {
 ## 更新履歴
 
 - 2025-06-20: 初版作成
+  - 文字エンコーディング問題修正（Unicode Escape Sequence使用）
   - `startsWith()` → `indexOf()` 修正
   - `Editor.SetLineStr()` 存在しない関数問題を修正
   - 正しいサクラエディタAPI使用方法に変更

--- a/indent-processor.js
+++ b/indent-processor.js
@@ -80,7 +80,7 @@ IndentProcessor.prototype.test = function() {
         var line = testCases[i];
         var parsed = this.parseIndent(line);
         var analysis = this.analyzeIndent(parsed.indent);
-        var replaced = this.replaceText(line, '□' + parsed.text);
+        var replaced = this.replaceText(line, '\u25A1' + parsed.text);  // □ 白四角
         
         results.push({
             original: line,

--- a/todo.md
+++ b/todo.md
@@ -61,12 +61,25 @@
 - `README.md` - プロジェクト説明とインストールガイド
 - `SETUP_GUIDE.md` - 詳細設定手順とトラブルシューティング
 - `COMPATIBILITY.md` - サクラエディタ互換性ガイド
+- `CHARACTER_ENCODING_GUIDE.md` - 文字エンコーディング対策ガイド
 
 ## 修正履歴
 ### 2025-06-20 互換性問題修正
+- ❌ 文字化け（□◆■→笹。箇・。） → ✅ Unicode Escape Sequence使用
 - ❌ `startsWith()` → ✅ `indexOf() === 0`
 - ❌ `Editor.SetLineStr()` (存在しない関数) → ✅ 正しいAPI組み合わせに修正
 - ES5準拠コードに統一
+
+### 文字エンコーディング修正詳細
+```javascript
+// 修正前（文字化けする）
+var symbols = ["□", "◆", "■"];
+if (text.indexOf("□") === 0) {
+
+// 修正後（文字化けしない）
+var symbols = ["\u25A1", "\u25C6", "\u25A0"];  // □ ◆ ■
+if (text.indexOf("\u25A1") === 0) {
+```
 
 ### API修正詳細
 ```javascript

--- a/todo_toggle_integrated.js
+++ b/todo_toggle_integrated.js
@@ -1,5 +1,6 @@
 // サクラエディタ TODO記号切り替えマクロ（統合版）
 // ショートカットキーで □ → ◆ → ■ → □ の循環切り替えを行う
+// Unicode文字（\u25A1 \u25C6 \u25A0）を使用して文字化けを防止
 
 /**
  * インデント処理クラス
@@ -54,7 +55,7 @@ var indentProcessor = new IndentProcessor();
  * @return {object} {symbol: string, remainingText: string}
  */
 function detectCurrentSymbol(text) {
-    var symbols = ["□", "◆", "■"];
+    var symbols = ["\u25A1", "\u25C6", "\u25A0"];  // □ ◆ ■
     
     for (var i = 0; i < symbols.length; i++) {
         var symbol = symbols[i];
@@ -80,15 +81,15 @@ function detectCurrentSymbol(text) {
  */
 function getNextSymbol(currentSymbol) {
     switch (currentSymbol) {
-        case "□":
-            return "◆";
-        case "◆":
-            return "■";
-        case "■":
-            return "□";
+        case "\u25A1":  // □ 白四角
+            return "\u25C6";  // ◆ 黒ダイヤ
+        case "\u25C6":  // ◆ 黒ダイヤ
+            return "\u25A0";  // ■ 黒四角
+        case "\u25A0":  // ■ 黒四角
+            return "\u25A1";  // □ 白四角
         default:
             // 記号がない場合は□を追加
-            return "□";
+            return "\u25A1";  // □ 白四角
     }
 }
 

--- a/toggle_todo_symbols.js
+++ b/toggle_todo_symbols.js
@@ -1,5 +1,6 @@
 // サクラエディタ TODO記号切り替えマクロ
 // ショートカットキーで □ → ◆ → ■ → □ の循環切り替えを行う
+// Unicode文字（\u25A1 \u25C6 \u25A0）を使用して文字化けを防止
 
 function main() {
     // 現在の行を取得
@@ -16,14 +17,14 @@ function main() {
     var currentSymbol = "";
     var remainingText = contentAfterIndent;
     
-    if (contentAfterIndent.indexOf("□") === 0) {
-        currentSymbol = "□";
+    if (contentAfterIndent.indexOf("\u25A1") === 0) {  // □ 白四角
+        currentSymbol = "\u25A1";
         remainingText = contentAfterIndent.substring(1);
-    } else if (contentAfterIndent.indexOf("◆") === 0) {
-        currentSymbol = "◆";
+    } else if (contentAfterIndent.indexOf("\u25C6") === 0) {  // ◆ 黒ダイヤ
+        currentSymbol = "\u25C6";
         remainingText = contentAfterIndent.substring(1);
-    } else if (contentAfterIndent.indexOf("■") === 0) {
-        currentSymbol = "■";
+    } else if (contentAfterIndent.indexOf("\u25A0") === 0) {  // ■ 黒四角
+        currentSymbol = "\u25A0";
         remainingText = contentAfterIndent.substring(1);
     }
     
@@ -42,15 +43,15 @@ function main() {
 // 記号状態判定ロジック：次の記号を決定する
 function getNextSymbol(currentSymbol) {
     switch (currentSymbol) {
-        case "□":
-            return "◆";
-        case "◆":
-            return "■";
-        case "■":
-            return "□";
+        case "\u25A1":  // □ 白四角
+            return "\u25C6";  // ◆ 黒ダイヤ
+        case "\u25C6":  // ◆ 黒ダイヤ
+            return "\u25A0";  // ■ 黒四角
+        case "\u25A0":  // ■ 黒四角
+            return "\u25A1";  // □ 白四角
         default:
             // 記号がない場合は□を追加
-            return "□";
+            return "\u25A1";  // □ 白四角
     }
 }
 


### PR DESCRIPTION
## 問題概要
TODO記号 □◆■ が文字化けして「笹。箇・。笹・・。」と表示されていた問題を修正。

## 文字化けパターン
- `□` → `笹。`
- `◆` → `箇・`  
- `■` → `笹・・`

## 原因
サクラエディタのShift_JIS環境とJavaScriptファイルのUTF-8エンコーディング間の不一致による文字化け。

## 解決方法

### Unicode Escape Sequenceへの変更
```javascript
// ❌ 修正前（文字化けする）
var symbols = ["□", "◆", "■"];
if (contentAfterIndent.indexOf("□") === 0) {

// ✅ 修正後（文字化けしない）
var symbols = ["\u25A1", "\u25C6", "\u25A0"];  // □ ◆ ■
if (contentAfterIndent.indexOf("\u25A1") === 0) {
```

## Unicode文字コード一覧
 < /dev/null |  記号 | 名前 | Unicodeコード | Escape Sequence |
|------|------|---------------|-----------------|
| □ | 白四角 | U+25A1 | `\u25A1` |
| ◆ | 黒ダイヤ | U+25C6 | `\u25C6` |
| ■ | 黒四角 | U+25A0 | `\u25A0` |

## 修正ファイル

### JavaScriptファイル
- **toggle_todo_symbols.js**: メインマクロの文字修正
- **todo_toggle_integrated.js**: 統合版マクロの文字修正
- **indent-processor.js**: テスト関数の文字修正

### ドキュメント
- **COMPATIBILITY.md**: 文字エンコーディング対策追加
- **CHARACTER_ENCODING_GUIDE.md**: 詳細ガイド新規作成
- **todo.md**: 修正履歴更新

## 新規追加ドキュメント

### CHARACTER_ENCODING_GUIDE.md
- 文字化け問題の詳細解説
- Unicode Escape Sequenceの使用方法
- 文字コード表
- 実装例とベストプラクティス
- トラブルシューティング

## 技術詳細

### 修正箇所
1. **記号配列の定義**
2. **条件分岐での記号判定**
3. **switch文での記号変換**
4. **テスト関数での記号使用**

### 期待される効果
- ✅ 環境に依存しない文字表示
- ✅ 文字化けの完全防止
- ✅ Shift_JIS/UTF-8両環境での動作
- ✅ 保守性の向上

## テスト計画
- [x] 全文字をUnicode Escape Sequenceに変更
- [x] 全対象ファイルの修正完了
- [x] ドキュメントの更新
- [x] 文字化け対策ガイド作成
- [ ] 実際のサクラエディタでの表示確認（ユーザー側）

## 受け入れ条件
- [x] 直接文字指定の完全削除
- [x] Unicode Escape Sequenceへの統一
- [x] 文字化け対策ドキュメント完備
- [x] 将来の文字化け問題予防策

これで□◆■が正しく表示されるようになります！

Closes #13

🤖 Generated with [Claude Code](https://claude.ai/code)