### PR TITLE
fix: Line 38 API エラーを修正（シンプル安全版に変更）

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -60,16 +60,22 @@ if (text.indexOf("□") !== -1) {
 // ❌ 存在しない関数
 Editor.SetLineStr(0, newLineText);
 
-// ✅ 正しい実装方法（絶対位置でカーソル位置保持）
-var currentLine = Editor.GetLineCount(1);     // 現在行番号を記憶
-var currentCol = Editor.GetSelectColumnFrom(); // 現在列位置を記憶
-
+// ✅ 正しい実装方法（シンプルで安全）
 Editor.GoLineTop(0);          // 行頭に移動
 Editor.SelectLine();          // 行全体を選択
 Editor.Delete();              // 選択行を削除
 Editor.InsText(newLineText);  // 新しい内容を挿入
+Editor.GoLineTop(0);          // 行頭に戻る
+```
 
-Editor.Jump(currentLine, 1);  // 絶対位置で行頭に確実に復元
+#### カーソル位置制御の注意点
+```javascript
+// ❌ API仕様不明で実行エラー
+var currentLine = Editor.GetLineCount(1);  // Line 38エラー
+Editor.Jump(currentLine, 1);
+
+// ✅ 確実に動作する基本的な方法
+Editor.GoLineTop(0);  // 行頭に移動（相対位置だが安全）
 ```
 
 #### `Editor.GetLineStr()` 使用方法

--- a/todo.md
+++ b/todo.md
@@ -98,8 +98,8 @@ Editor.InsText(newLineText);  // 新しい内容を挿入
 Editor.Jump(currentLine, 1);  // 絶対位置で行頭に確実に復元
 ```
 
-### カーソル位置修正詳細（v2）
-- `Editor.GetLineCount(1)` で現在行番号を数値で記憶
-- `Editor.GetSelectColumnFrom()` で現在列位置を数値で記憶  
-- `Editor.Jump(行番号, 列番号)` で絶対位置指定による確実な復元
-- 相対移動ではなく絶対座標による安定したカーソル制御
+### API問題修正詳細（v3: シンプル安全版）
+- `Editor.GetLineCount(1)` でLine 38エラーが発生
+- API仕様不明のため、複雑なカーソル制御を諦める
+- `Editor.GoLineTop(0)` による基本的な行頭復帰に変更
+- 確実に動作する安全な実装を優先

--- a/todo_toggle_integrated.js
+++ b/todo_toggle_integrated.js
@@ -116,16 +116,12 @@ function main() {
     // インデント処理モジュールを使用して新しい行を構築
     var newLineText = indentProcessor.replaceText(currentLineText, newText);
     
-    // 現在の行を新しい内容で置換（絶対位置でカーソル位置を確実に保持）
-    var currentLine = Editor.GetLineCount(1);     // 現在行番号を記憶
-    var currentCol = Editor.GetSelectColumnFrom(); // 現在列位置を記憶
-    
+    // 現在の行を新しい内容で置換（シンプルで安全な実装）
     Editor.GoLineTop(0);          // 行頭に移動
     Editor.SelectLine();          // 行全体を選択
     Editor.Delete();              // 選択行を削除
     Editor.InsText(newLineText);  // 新しい内容を挿入
-    
-    Editor.Jump(currentLine, 1);  // 絶対位置で行頭に確実に復元
+    Editor.GoLineTop(0);          // 行頭に戻る
 }
 
 // マクロのエントリーポイント

--- a/toggle_todo_symbols.js
+++ b/toggle_todo_symbols.js
@@ -34,16 +34,12 @@ function main() {
     // 新しい行の内容を構築
     var newLineText = indentPart + nextSymbol + remainingText;
     
-    // 現在の行を新しい内容で置換（絶対位置でカーソル位置を確実に保持）
-    var currentLine = Editor.GetLineCount(1);     // 現在行番号を記憶
-    var currentCol = Editor.GetSelectColumnFrom(); // 現在列位置を記憶
-    
+    // 現在の行を新しい内容で置換（シンプルで安全な実装）
     Editor.GoLineTop(0);          // 行頭に移動
     Editor.SelectLine();          // 行全体を選択
     Editor.Delete();              // 選択行を削除
     Editor.InsText(newLineText);  // 新しい内容を挿入
-    
-    Editor.Jump(currentLine, 1);  // 絶対位置で行頭に確実に復元
+    Editor.GoLineTop(0);          // 行頭に戻る
 }
 
 // 記号状態判定ロジック：次の記号を決定する


### PR DESCRIPTION
## 問題概要
Line 38で「マクロの実行を中断しました」エラーが発生し、マクロが実行できない致命的問題を修正。

## エラー詳細
```javascript
var currentLine = Editor.GetLineCount(1);     // Line 38でエラー
```

## 原因分析
1. **API仕様の誤解**: `Editor.GetLineCount()` は総行数取得関数であり、現在行番号取得ではない
2. **不正な引数**: `GetLineCount(1)` の引数 `1` が不正
3. **存在しないAPI**: 現在行番号取得の正しいAPIが不明

## 解決方針
**安定性を最優先**とし、複雑なカーソル位置制御を一旦諦めて、確実に動作するシンプルな実装に変更。

## 修正内容

### 修正前（Line 38エラー）
```javascript
var currentLine = Editor.GetLineCount(1);     // エラー発生
var currentCol = Editor.GetSelectColumnFrom(); 

Editor.GoLineTop(0);
Editor.SelectLine();
Editor.Delete();
Editor.InsText(newLineText);

Editor.Jump(currentLine, 1);  // 実行されない
```

### 修正後（シンプルで安全）
```javascript
Editor.GoLineTop(0);          // 行頭に移動
Editor.SelectLine();          // 行全体を選択
Editor.Delete();              // 選択行を削除
Editor.InsText(newLineText);  // 新しい内容を挿入
Editor.GoLineTop(0);          // 行頭に戻る
```

## 技術的判断

### 優先順位
1. **最優先**: マクロが実行される
2. **次点**: カーソル位置制御の改善
3. **将来**: 正しいAPIの調査と実装

### トレードオフ
- ✅ **メリット**: マクロが確実に実行される
- ✅ **メリット**: 記号切り替え機能は完全に動作
- ❌ **デメリット**: カーソル位置制御は基本レベル
- 🔄 **将来性**: 正しいAPIが判明すれば改善可能

## 修正ファイル

### JavaScriptファイル
- **toggle_todo_symbols.js**: 問題のあるAPI削除、安全な実装に変更
- **todo_toggle_integrated.js**: 問題のあるAPI削除、安全な実装に変更

### ドキュメント
- **COMPATIBILITY.md**: API注意点とエラー回避方法を追記
- **todo.md**: 修正詳細（v3: シンプル安全版）を更新

## 動作確認

### 期待される動作
1. **マクロ実行**: エラーなく正常に実行される
2. **記号切り替え**: □→◆→■→□が正しく動作
3. **インデント保持**: 既存機能は維持
4. **カーソル位置**: 行頭に移動（完璧ではないが実用的）

### 改善点
- マクロが実行できなかった致命的問題の解消
- 安定性の大幅向上
- 将来の改善への基盤確立

## 今後の改善計画
1. サクラエディタの正確なAPI仕様調査
2. 現在行番号取得の正しい方法の特定
3. より高度なカーソル位置制御の実装

**まずは動作するマクロを提供し、段階的に改善していく方針です。**

Closes #19

🤖 Generated with [Claude Code](https://claude.ai/code)